### PR TITLE
Bulk export & Alphabetical asset sorting

### DIFF
--- a/BARSReaderGUI/Form1.Designer.cs
+++ b/BARSReaderGUI/Form1.Designer.cs
@@ -29,251 +29,262 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.AssetListBox = new System.Windows.Forms.ListBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.AudioAssetIsPrefetchLabel = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.extractMetaButton = new System.Windows.Forms.Button();
-            this.extractAudioButton = new System.Windows.Forms.Button();
-            this.AudioAssetBwavOffsetLabel = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.AudioAssetAmtaOffsetLabel = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.AudioAssetCrc32HashLabel = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.AudioAssetNameLabel = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.menuStrip1.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.SuspendLayout();
+            menuStrip1 = new MenuStrip();
+            fileToolStripMenuItem = new ToolStripMenuItem();
+            openToolStripMenuItem = new ToolStripMenuItem();
+            groupBox1 = new GroupBox();
+            AssetListBox = new ListBox();
+            groupBox2 = new GroupBox();
+            extractAllButton = new Button();
+            AudioAssetIsPrefetchLabel = new Label();
+            label5 = new Label();
+            extractMetaButton = new Button();
+            extractAudioButton = new Button();
+            AudioAssetBwavOffsetLabel = new Label();
+            label4 = new Label();
+            AudioAssetAmtaOffsetLabel = new Label();
+            label3 = new Label();
+            AudioAssetCrc32HashLabel = new Label();
+            label2 = new Label();
+            AudioAssetNameLabel = new Label();
+            label1 = new Label();
+            menuStrip1.SuspendLayout();
+            groupBox1.SuspendLayout();
+            groupBox2.SuspendLayout();
+            SuspendLayout();
             // 
             // menuStrip1
             // 
-            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(32, 32);
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(3, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(529, 24);
-            this.menuStrip1.TabIndex = 0;
-            this.menuStrip1.Text = "menuStrip1";
+            menuStrip1.ImageScalingSize = new Size(32, 32);
+            menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem });
+            menuStrip1.Location = new Point(0, 0);
+            menuStrip1.Name = "menuStrip1";
+            menuStrip1.Padding = new Padding(3, 1, 0, 1);
+            menuStrip1.Size = new Size(529, 24);
+            menuStrip1.TabIndex = 0;
+            menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
-            this.fileToolStripMenuItem.Text = "File";
+            fileToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { openToolStripMenuItem });
+            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            fileToolStripMenuItem.Size = new Size(37, 22);
+            fileToolStripMenuItem.Text = "File";
             // 
             // openToolStripMenuItem
             // 
-            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(112, 22);
-            this.openToolStripMenuItem.Text = "Open...";
-            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            openToolStripMenuItem.Name = "openToolStripMenuItem";
+            openToolStripMenuItem.Size = new Size(112, 22);
+            openToolStripMenuItem.Text = "Open...";
+            openToolStripMenuItem.Click += openToolStripMenuItem_Click;
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.AssetListBox);
-            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Left;
-            this.groupBox1.Location = new System.Drawing.Point(0, 24);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.groupBox1.Size = new System.Drawing.Size(310, 297);
-            this.groupBox1.TabIndex = 1;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Assets";
+            groupBox1.Controls.Add(AssetListBox);
+            groupBox1.Dock = DockStyle.Left;
+            groupBox1.Location = new Point(0, 24);
+            groupBox1.Margin = new Padding(2, 1, 2, 1);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Padding = new Padding(2, 1, 2, 1);
+            groupBox1.Size = new Size(310, 297);
+            groupBox1.TabIndex = 1;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Assets";
             // 
             // AssetListBox
             // 
-            this.AssetListBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AssetListBox.FormattingEnabled = true;
-            this.AssetListBox.ItemHeight = 15;
-            this.AssetListBox.Location = new System.Drawing.Point(2, 17);
-            this.AssetListBox.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.AssetListBox.Name = "AssetListBox";
-            this.AssetListBox.Size = new System.Drawing.Size(306, 279);
-            this.AssetListBox.TabIndex = 0;
-            this.AssetListBox.SelectedIndexChanged += new System.EventHandler(this.AssetListBox_SelectedIndexChanged);
+            AssetListBox.Dock = DockStyle.Fill;
+            AssetListBox.FormattingEnabled = true;
+            AssetListBox.ItemHeight = 15;
+            AssetListBox.Location = new Point(2, 17);
+            AssetListBox.Margin = new Padding(2, 1, 2, 1);
+            AssetListBox.Name = "AssetListBox";
+            AssetListBox.Size = new Size(306, 279);
+            AssetListBox.TabIndex = 0;
+            AssetListBox.SelectedIndexChanged += AssetListBox_SelectedIndexChanged;
             // 
             // groupBox2
             // 
-            this.groupBox2.Controls.Add(this.AudioAssetIsPrefetchLabel);
-            this.groupBox2.Controls.Add(this.label5);
-            this.groupBox2.Controls.Add(this.extractMetaButton);
-            this.groupBox2.Controls.Add(this.extractAudioButton);
-            this.groupBox2.Controls.Add(this.AudioAssetBwavOffsetLabel);
-            this.groupBox2.Controls.Add(this.label4);
-            this.groupBox2.Controls.Add(this.AudioAssetAmtaOffsetLabel);
-            this.groupBox2.Controls.Add(this.label3);
-            this.groupBox2.Controls.Add(this.AudioAssetCrc32HashLabel);
-            this.groupBox2.Controls.Add(this.label2);
-            this.groupBox2.Controls.Add(this.AudioAssetNameLabel);
-            this.groupBox2.Controls.Add(this.label1);
-            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Right;
-            this.groupBox2.Location = new System.Drawing.Point(314, 24);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.groupBox2.Size = new System.Drawing.Size(215, 297);
-            this.groupBox2.TabIndex = 2;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Asset Info";
+            groupBox2.Controls.Add(extractAllButton);
+            groupBox2.Controls.Add(AudioAssetIsPrefetchLabel);
+            groupBox2.Controls.Add(label5);
+            groupBox2.Controls.Add(extractMetaButton);
+            groupBox2.Controls.Add(extractAudioButton);
+            groupBox2.Controls.Add(AudioAssetBwavOffsetLabel);
+            groupBox2.Controls.Add(label4);
+            groupBox2.Controls.Add(AudioAssetAmtaOffsetLabel);
+            groupBox2.Controls.Add(label3);
+            groupBox2.Controls.Add(AudioAssetCrc32HashLabel);
+            groupBox2.Controls.Add(label2);
+            groupBox2.Controls.Add(AudioAssetNameLabel);
+            groupBox2.Controls.Add(label1);
+            groupBox2.Dock = DockStyle.Right;
+            groupBox2.Location = new Point(314, 24);
+            groupBox2.Margin = new Padding(2, 1, 2, 1);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Padding = new Padding(2, 1, 2, 1);
+            groupBox2.Size = new Size(215, 297);
+            groupBox2.TabIndex = 2;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Asset Info";
+            // 
+            // extractAllButton
+            // 
+            extractAllButton.Enabled = false;
+            extractAllButton.Location = new Point(3, 273);
+            extractAllButton.Margin = new Padding(2, 1, 2, 1);
+            extractAllButton.Name = "extractAllButton";
+            extractAllButton.Size = new Size(207, 22);
+            extractAllButton.TabIndex = 12;
+            extractAllButton.Text = "Extract All Audio";
+            extractAllButton.UseVisualStyleBackColor = true;
+            extractAllButton.Click += extractAllButton_Click;
             // 
             // AudioAssetIsPrefetchLabel
             // 
-            this.AudioAssetIsPrefetchLabel.AutoSize = true;
-            this.AudioAssetIsPrefetchLabel.Location = new System.Drawing.Point(3, 151);
-            this.AudioAssetIsPrefetchLabel.Name = "AudioAssetIsPrefetchLabel";
-            this.AudioAssetIsPrefetchLabel.Size = new System.Drawing.Size(59, 15);
-            this.AudioAssetIsPrefetchLabel.TabIndex = 11;
-            this.AudioAssetIsPrefetchLabel.Text = "isprefetch";
+            AudioAssetIsPrefetchLabel.AutoSize = true;
+            AudioAssetIsPrefetchLabel.Location = new Point(3, 151);
+            AudioAssetIsPrefetchLabel.Name = "AudioAssetIsPrefetchLabel";
+            AudioAssetIsPrefetchLabel.Size = new Size(59, 15);
+            AudioAssetIsPrefetchLabel.TabIndex = 11;
+            AudioAssetIsPrefetchLabel.Text = "isprefetch";
             // 
             // label5
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 136);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(59, 15);
-            this.label5.TabIndex = 10;
-            this.label5.Text = "IsPrefetch";
+            label5.AutoSize = true;
+            label5.Location = new Point(3, 136);
+            label5.Name = "label5";
+            label5.Size = new Size(59, 15);
+            label5.TabIndex = 10;
+            label5.Text = "IsPrefetch";
             // 
             // extractMetaButton
             // 
-            this.extractMetaButton.Enabled = false;
-            this.extractMetaButton.Location = new System.Drawing.Point(3, 231);
-            this.extractMetaButton.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.extractMetaButton.Name = "extractMetaButton";
-            this.extractMetaButton.Size = new System.Drawing.Size(207, 22);
-            this.extractMetaButton.TabIndex = 9;
-            this.extractMetaButton.Text = "Extract Meta";
-            this.extractMetaButton.UseVisualStyleBackColor = true;
-            this.extractMetaButton.Click += new System.EventHandler(this.extractMetaButton_Click);
+            extractMetaButton.Enabled = false;
+            extractMetaButton.Location = new Point(4, 225);
+            extractMetaButton.Margin = new Padding(2, 1, 2, 1);
+            extractMetaButton.Name = "extractMetaButton";
+            extractMetaButton.Size = new Size(207, 22);
+            extractMetaButton.TabIndex = 9;
+            extractMetaButton.Text = "Extract Meta";
+            extractMetaButton.UseVisualStyleBackColor = true;
+            extractMetaButton.Click += extractMetaButton_Click;
             // 
             // extractAudioButton
             // 
-            this.extractAudioButton.Enabled = false;
-            this.extractAudioButton.Location = new System.Drawing.Point(4, 265);
-            this.extractAudioButton.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.extractAudioButton.Name = "extractAudioButton";
-            this.extractAudioButton.Size = new System.Drawing.Size(207, 22);
-            this.extractAudioButton.TabIndex = 8;
-            this.extractAudioButton.Text = "Extract Audio";
-            this.extractAudioButton.UseVisualStyleBackColor = true;
-            this.extractAudioButton.Click += new System.EventHandler(this.extractAudioButton_Click);
+            extractAudioButton.Enabled = false;
+            extractAudioButton.Location = new Point(3, 249);
+            extractAudioButton.Margin = new Padding(2, 1, 2, 1);
+            extractAudioButton.Name = "extractAudioButton";
+            extractAudioButton.Size = new Size(207, 22);
+            extractAudioButton.TabIndex = 8;
+            extractAudioButton.Text = "Extract Audio";
+            extractAudioButton.UseVisualStyleBackColor = true;
+            extractAudioButton.Click += extractAudioButton_Click;
             // 
             // AudioAssetBwavOffsetLabel
             // 
-            this.AudioAssetBwavOffsetLabel.AutoSize = true;
-            this.AudioAssetBwavOffsetLabel.Location = new System.Drawing.Point(3, 121);
-            this.AudioAssetBwavOffsetLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.AudioAssetBwavOffsetLabel.Name = "AudioAssetBwavOffsetLabel";
-            this.AudioAssetBwavOffsetLabel.Size = new System.Drawing.Size(65, 15);
-            this.AudioAssetBwavOffsetLabel.TabIndex = 7;
-            this.AudioAssetBwavOffsetLabel.Text = "assetOffset";
+            AudioAssetBwavOffsetLabel.AutoSize = true;
+            AudioAssetBwavOffsetLabel.Location = new Point(3, 121);
+            AudioAssetBwavOffsetLabel.Margin = new Padding(2, 0, 2, 0);
+            AudioAssetBwavOffsetLabel.Name = "AudioAssetBwavOffsetLabel";
+            AudioAssetBwavOffsetLabel.Size = new Size(65, 15);
+            AudioAssetBwavOffsetLabel.TabIndex = 7;
+            AudioAssetBwavOffsetLabel.Text = "assetOffset";
             // 
             // label4
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 106);
-            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(70, 15);
-            this.label4.TabIndex = 6;
-            this.label4.Text = "Asset Offset";
+            label4.AutoSize = true;
+            label4.Location = new Point(3, 106);
+            label4.Margin = new Padding(2, 0, 2, 0);
+            label4.Name = "label4";
+            label4.Size = new Size(70, 15);
+            label4.TabIndex = 6;
+            label4.Text = "Asset Offset";
             // 
             // AudioAssetAmtaOffsetLabel
             // 
-            this.AudioAssetAmtaOffsetLabel.AutoSize = true;
-            this.AudioAssetAmtaOffsetLabel.Location = new System.Drawing.Point(3, 91);
-            this.AudioAssetAmtaOffsetLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.AudioAssetAmtaOffsetLabel.Name = "AudioAssetAmtaOffsetLabel";
-            this.AudioAssetAmtaOffsetLabel.Size = new System.Drawing.Size(66, 15);
-            this.AudioAssetAmtaOffsetLabel.TabIndex = 5;
-            this.AudioAssetAmtaOffsetLabel.Text = "amtaOffset";
+            AudioAssetAmtaOffsetLabel.AutoSize = true;
+            AudioAssetAmtaOffsetLabel.Location = new Point(3, 91);
+            AudioAssetAmtaOffsetLabel.Margin = new Padding(2, 0, 2, 0);
+            AudioAssetAmtaOffsetLabel.Name = "AudioAssetAmtaOffsetLabel";
+            AudioAssetAmtaOffsetLabel.Size = new Size(66, 15);
+            AudioAssetAmtaOffsetLabel.TabIndex = 5;
+            AudioAssetAmtaOffsetLabel.Text = "amtaOffset";
             // 
             // label3
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 76);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(69, 15);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Meta Offset";
+            label3.AutoSize = true;
+            label3.Location = new Point(3, 76);
+            label3.Margin = new Padding(2, 0, 2, 0);
+            label3.Name = "label3";
+            label3.Size = new Size(69, 15);
+            label3.TabIndex = 4;
+            label3.Text = "Meta Offset";
             // 
             // AudioAssetCrc32HashLabel
             // 
-            this.AudioAssetCrc32HashLabel.AutoSize = true;
-            this.AudioAssetCrc32HashLabel.Location = new System.Drawing.Point(3, 61);
-            this.AudioAssetCrc32HashLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.AudioAssetCrc32HashLabel.Name = "AudioAssetCrc32HashLabel";
-            this.AudioAssetCrc32HashLabel.Size = new System.Drawing.Size(50, 15);
-            this.AudioAssetCrc32HashLabel.TabIndex = 3;
-            this.AudioAssetCrc32HashLabel.Text = "crcHash";
+            AudioAssetCrc32HashLabel.AutoSize = true;
+            AudioAssetCrc32HashLabel.Location = new Point(3, 61);
+            AudioAssetCrc32HashLabel.Margin = new Padding(2, 0, 2, 0);
+            AudioAssetCrc32HashLabel.Name = "AudioAssetCrc32HashLabel";
+            AudioAssetCrc32HashLabel.Size = new Size(50, 15);
+            AudioAssetCrc32HashLabel.TabIndex = 3;
+            AudioAssetCrc32HashLabel.Text = "crcHash";
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 46);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(69, 15);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "Name Hash";
+            label2.AutoSize = true;
+            label2.Location = new Point(3, 46);
+            label2.Margin = new Padding(2, 0, 2, 0);
+            label2.Name = "label2";
+            label2.Size = new Size(69, 15);
+            label2.TabIndex = 2;
+            label2.Text = "Name Hash";
             // 
             // AudioAssetNameLabel
             // 
-            this.AudioAssetNameLabel.AutoSize = true;
-            this.AudioAssetNameLabel.Location = new System.Drawing.Point(3, 31);
-            this.AudioAssetNameLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.AudioAssetNameLabel.Name = "AudioAssetNameLabel";
-            this.AudioAssetNameLabel.Size = new System.Drawing.Size(63, 15);
-            this.AudioAssetNameLabel.TabIndex = 1;
-            this.AudioAssetNameLabel.Text = "assetname";
+            AudioAssetNameLabel.AutoSize = true;
+            AudioAssetNameLabel.Location = new Point(3, 31);
+            AudioAssetNameLabel.Margin = new Padding(2, 0, 2, 0);
+            AudioAssetNameLabel.Name = "AudioAssetNameLabel";
+            AudioAssetNameLabel.Size = new Size(63, 15);
+            AudioAssetNameLabel.TabIndex = 1;
+            AudioAssetNameLabel.Text = "assetname";
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 16);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(39, 15);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Name";
+            label1.AutoSize = true;
+            label1.Location = new Point(3, 16);
+            label1.Margin = new Padding(2, 0, 2, 0);
+            label1.Name = "label1";
+            label1.Size = new Size(39, 15);
+            label1.TabIndex = 0;
+            label1.Text = "Name";
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(529, 321);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.menuStrip1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
-            this.MaximizeBox = false;
-            this.Name = "Form1";
-            this.Text = "BARSReaderGUI";
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            BackColor = SystemColors.Control;
+            ClientSize = new Size(529, 321);
+            Controls.Add(groupBox2);
+            Controls.Add(groupBox1);
+            Controls.Add(menuStrip1);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            Icon = (Icon)resources.GetObject("$this.Icon");
+            MainMenuStrip = menuStrip1;
+            Margin = new Padding(2, 1, 2, 1);
+            MaximizeBox = false;
+            Name = "Form1";
+            Text = "BARSReaderGUI";
+            menuStrip1.ResumeLayout(false);
+            menuStrip1.PerformLayout();
+            groupBox1.ResumeLayout(false);
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -296,5 +307,6 @@
         private Button extractMetaButton;
         private Label AudioAssetIsPrefetchLabel;
         private Label label5;
+        private Button extractAllButton;
     }
 }

--- a/BARSReaderGUI/Form1.cs
+++ b/BARSReaderGUI/Form1.cs
@@ -16,6 +16,7 @@ namespace BARSReaderGUI
         {
             Stream fileStream;
             OpenFileDialog fileDialog = new OpenFileDialog();
+            fileDialog.Filter = "BARS files (*.bars, *.bars.zs)|*.bars;*.bars.zs";
 
             if (fileDialog.ShowDialog() == DialogResult.OK)
             {

--- a/BARSReaderGUI/Form1.cs
+++ b/BARSReaderGUI/Form1.cs
@@ -3,6 +3,9 @@ namespace BARSReaderGUI
     public partial class Form1 : Form
     {
         List<AudioAsset> audioAssets = new List<AudioAsset>();
+        // stores all of the names of the BWAVs in a BARS file
+        // used when sorting to get the index of the actual sound
+        List<String> audioNames = new List<string>();
 
         public Form1()
         {
@@ -17,6 +20,7 @@ namespace BARSReaderGUI
             if (fileDialog.ShowDialog() == DialogResult.OK)
             {
                 audioAssets.Clear();
+                audioNames.Clear();
                 AssetListBox.Items.Clear();
                 string inputFile = fileDialog.FileName;
 
@@ -138,10 +142,14 @@ namespace BARSReaderGUI
 
                     // Adds all of the audio asset names to the main list box.
                     for (int i = 0; i < audioAssets.Count; i++)
+                    {
                         AssetListBox.Items.Add(audioAssets[i].amtaData.assetName);
+                        audioNames.Add(audioAssets[i].amtaData.assetName);
+                    }
 
                     this.Text = $"BARSReaderGUI - {fileDialog.SafeFileName} - {assetcount} Assets";
                     MessageBox.Show("Successfully read " + assetcount + " assets.");
+                    AssetListBox.Sorted = true;
                 }
             }
         }
@@ -152,7 +160,8 @@ namespace BARSReaderGUI
             {
                 extractAudioButton.Enabled = true;
                 extractMetaButton.Enabled = true;
-                int index = AssetListBox.SelectedIndex;
+                String sortedAssetName = AssetListBox.Items[AssetListBox.SelectedIndex].ToString();
+                int index = audioNames.FindIndex(s => s.Contains(sortedAssetName));
                 AudioAssetNameLabel.Text = audioAssets[index].amtaData.assetName;
                 AudioAssetCrc32HashLabel.Text = audioAssets[index].crcHash.ToString("X");
                 AudioAssetAmtaOffsetLabel.Text = audioAssets[index].amtaOffset.ToString("X");

--- a/BARSReaderGUI/Form1.cs
+++ b/BARSReaderGUI/Form1.cs
@@ -112,7 +112,7 @@ namespace BARSReaderGUI
                         audioAssets[i].assetType = reader.ReadSizedString(4);
                         reader.Position -= 4;
 
-                        
+
                         if (audioAssets[i].assetType != "BWAV")
                         {
                             //FSTPs are prefetch assets.
@@ -150,6 +150,7 @@ namespace BARSReaderGUI
                     this.Text = $"BARSReaderGUI - {fileDialog.SafeFileName} - {assetcount} Assets";
                     MessageBox.Show("Successfully read " + assetcount + " assets.");
                     AssetListBox.Sorted = true;
+                    extractAllButton.Enabled = true;
                 }
             }
         }
@@ -173,6 +174,7 @@ namespace BARSReaderGUI
             {
                 extractAudioButton.Enabled = false;
                 extractMetaButton.Enabled = false;
+                extractAllButton.Enabled = false;
             }
         }
 
@@ -195,7 +197,7 @@ namespace BARSReaderGUI
                 default:
                     break;
             }// Change this later to handle other audio formats
-            
+
             saveFileDialog.Title = "Extract Audio";
             saveFileDialog.FileName = audioAssets[AssetListBox.SelectedIndex].amtaData.assetName;
             saveFileDialog.RestoreDirectory = true;
@@ -259,6 +261,28 @@ namespace BARSReaderGUI
                 audioAssets.RemoveAt(lowestToSave);
             }
             return sortedAssets;
+        }
+
+        private void extractAllButton_Click(object sender, EventArgs e)
+        {
+            // Select export folder
+            FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog();
+            folderBrowserDialog.RootFolder = Environment.SpecialFolder.Personal;
+
+            if (folderBrowserDialog.ShowDialog() == DialogResult.OK)
+            {
+                int assetcount = 0;
+                // Iterate through each entry and export.
+                audioAssets.ForEach(asset =>
+                {
+                    String fileName = folderBrowserDialog.SelectedPath + "\\" + asset.amtaData.assetName + "." + asset.assetType;
+                    using var writer = new BinaryWriter(File.Create(fileName));
+                    writer.Write(asset.assetData);
+                    assetcount++;
+                });
+
+                MessageBox.Show("Successfully extracted " + assetcount + " sounds.");
+            }
         }
     }
     public class AssetOffsetPair

--- a/BARSReaderGUI/Form1.cs
+++ b/BARSReaderGUI/Form1.cs
@@ -161,7 +161,7 @@ namespace BARSReaderGUI
             {
                 extractAudioButton.Enabled = true;
                 extractMetaButton.Enabled = true;
-                String sortedAssetName = AssetListBox.Items[AssetListBox.SelectedIndex].ToString();
+                String sortedAssetName = AssetListBox.Items[AssetListBox.SelectedIndex].ToString() ?? audioAssets[0].amtaData.assetName;
                 int index = audioNames.FindIndex(s => s.Contains(sortedAssetName));
                 AudioAssetNameLabel.Text = audioAssets[index].amtaData.assetName;
                 AudioAssetCrc32HashLabel.Text = audioAssets[index].crcHash.ToString("X");


### PR DESCRIPTION
from these two issues: https://github.com/NatalieWhatever/BARSReaderGUI/issues/1, https://github.com/NatalieWhatever/BARSReaderGUI/issues/2

(unsorted version)
![image](https://user-images.githubusercontent.com/36908123/230713622-e6f269d5-992e-461c-b9c7-3c9849678bc9.png)

(sorted version)
![image](https://user-images.githubusercontent.com/36908123/230713565-2421f683-6e95-481a-a17e-8f223647f633.png)

files are sorted alphabetically now by default, and will retain the same information they had prior. `audioNames` is used to keep the internal order of the sounds, which lets the UI list be sorted without issue.

adds a button named "Export All Audio" (of course) which lets you choose an export folder and exports the entirety of `audioAssets` to that folder in their proper format.